### PR TITLE
sort private and group chats

### DIFF
--- a/frontend/components/chatList.tsx
+++ b/frontend/components/chatList.tsx
@@ -87,7 +87,15 @@ export default function ChatList({ activeChat, setActiveChat }: ChatListProps) {
             isOnline: false,
           })),
         ];
-
+        transformedChats.sort((a, b) => {
+          const dateA = a.lastMessageTime
+            ? new Date(a.lastMessageTime)
+            : new Date(0);
+          const dateB = b.lastMessageTime
+            ? new Date(b.lastMessageTime)
+            : new Date(0);
+          return dateB.getTime() - dateA.getTime();
+        });
         setChats(transformedChats);
         setLoading(false);
       } catch (error) {


### PR DESCRIPTION
- Modified backend query to retrieve lastMessage.text and lastMessage.data along with each private/group chats.
- Added sort function in frontend to sort chats from last updated to oldest.