### PR TITLE
FIX

### DIFF
--- a/backend/pkg/controller/app.go
+++ b/backend/pkg/controller/app.go
@@ -11,8 +11,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"slices"
+
+	"github.com/gorilla/websocket"
 )
 
 type App struct {

--- a/frontend/components/ErrorPopup.tsx
+++ b/frontend/components/ErrorPopup.tsx
@@ -1,4 +1,3 @@
-// components/ErrorPopup.tsx
 "use client";
 
 import { useError } from "@/context/ErrorContext";

--- a/frontend/components/create-group-modal.tsx
+++ b/frontend/components/create-group-modal.tsx
@@ -23,6 +23,31 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [image, setImage] = useState<File | null>(null);
   const [disableButton, setDisableButton] = useState(false);
+  const [errors, setErrors] = useState<{
+    title?: string;
+    description?: string;
+  }>({});
+
+  const titleRegex = /^[a-zA-Z0-9\s\-]{3,50}$/;
+
+  const validateInputs = () => {
+    const newErrors: { title?: string; description?: string } = {};
+
+    if (!title.trim()) {
+      newErrors.title = "Group title is required.";
+    } else if (!titleRegex.test(title)) {
+      newErrors.title =
+        "Title must be 3-50 characters and contain only letters, numbers, spaces, or dashes.";
+    }
+
+    if (description.length > 300) {
+      newErrors.description = "Description must be 300 characters or less.";
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -37,6 +62,8 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!validateInputs()) return;
+
     setDisableButton(true);
     try {
       let imageUrl = "";
@@ -53,12 +80,9 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
         description,
       });
     } catch (err) {
-      // setPopup({ message: `${err}`, status: "failure" });
-      setDisableButton(true);
-
       console.error(err);
     } finally {
-      setDisableButton(true);
+      setDisableButton(false);
     }
   };
 
@@ -87,7 +111,6 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
                   />
                 </label>
               </div>
-
               {imagePreview && (
                 <div className="image-preview">
                   <Image
@@ -113,6 +136,7 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
               />
+              {errors.title && <p className="form-error">{errors.title}</p>}
             </div>
 
             <div className="form-group">
@@ -126,6 +150,9 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
               />
+              {errors.description && (
+                <p className="form-error">{errors.description}</p>
+              )}
             </div>
           </div>
 
@@ -144,7 +171,7 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
             <button
               type="submit"
               className="create-post-btn"
-              disabled = {disableButton}
+              disabled={disableButton}
             >
               Create Group
             </button>

--- a/frontend/components/create-group-modal.tsx
+++ b/frontend/components/create-group-modal.tsx
@@ -22,6 +22,7 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
   const [description, setDescription] = useState("");
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [image, setImage] = useState<File | null>(null);
+  const [disableButton, setDisableButton] = useState(false);
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (file) {
@@ -36,7 +37,7 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
+    setDisableButton(true);
     try {
       let imageUrl = "";
 
@@ -53,7 +54,11 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
       });
     } catch (err) {
       // setPopup({ message: `${err}`, status: "failure" });
+      setDisableButton(true);
+
       console.error(err);
+    } finally {
+      setDisableButton(true);
     }
   };
 
@@ -136,7 +141,11 @@ const CreateGroupModal: React.FC<CreateGroupModalProps> = ({
             >
               Cancel
             </button>
-            <button type="submit" className="create-post-btn">
+            <button
+              type="submit"
+              className="create-post-btn"
+              disabled = {disableButton}
+            >
               Create Group
             </button>
           </div>

--- a/frontend/helpers/webSocket.ts
+++ b/frontend/helpers/webSocket.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import getToken from "@/api/auth/getToken";
-//import { handleAPIError } from "./GlobalAPIHelper";
+import { getGlobalErrorHandler } from "@/context/ErrorContext";
 
 export let socket: WebSocket | null = null;
 
@@ -24,10 +24,11 @@ export const connectWebSocket = async (): Promise<WebSocket | null> => {
         console.log("WebSocket message received:", data);
 
         if (data.error) {
-          // handleAPIError(
-          //   data.error.cause || "Unknown error",
-          //   data.error.code || 500
-          // );
+          const showError = getGlobalErrorHandler();
+          showError(
+            data.error.cause || "Unknown WebSocket error",
+            data.error.code || 500
+          );
           console.warn("WebSocket error:", data.error);
           return;
         }
@@ -45,7 +46,6 @@ export const connectWebSocket = async (): Promise<WebSocket | null> => {
     socket.onerror = (err) => {
       console.error("WebSocket error:", err);
     };
-
 
     return socket;
   } catch (error) {


### PR DESCRIPTION
[FIX]:

CREATE A GLO ERROR CONTEXT GLOBAL REFERENCE TO BYPASS THE REACT HOOK PROPLEM AND USE THE SHOW ERROR IN WEBSOCKET.

INPUT VALIDATION FOR GROUP CREATION FRONT AND BACK SIDE --AVOIDING SPAM--.

CLOSING WEBSOCKET IN CASE THE ERROR IS "UNAUTHORIZED", SOO THE WEBSOCKET CLOSED WHEN QUICKING A USER.

